### PR TITLE
make tooltip info type truly optional, as documented

### DIFF
--- a/px-vis-central-tooltip-content.html
+++ b/px-vis-central-tooltip-content.html
@@ -54,7 +54,7 @@ limitations under the License.
 
           <template id="infoTemplate" is="dom-repeat" items="[[_currentData.data]]" as="info">
             <div class="flex flex--justify u-mt--">
-              <span class="u-mr"><b>[[localize(info.title)]]</b>:</span> <span>[[_formatData(info.value, info.type)]]</span>
+              <span class="u-mr"><b>[[localize(info.title)]]</b>:</span> <span>[[_formatInfo(info)]]</span>
             </div>
           </template>
 
@@ -246,6 +246,10 @@ limitations under the License.
       }
 
       return data
+    },
+
+    _formatInfo: function(info) {
+      return this._formatData(info.value, info.type || '');
     },
 
     _formatWholeTimestamp: function(time) {


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
the _currentData property of px-vis-central-tooltip-content describes the item.type property as optional, but the computed binding includes it as a dependency, which makes it required. The change introduces a formatInfo() method which only depends on the item, so if type is omitted it still works.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:
@benoitjchevalier 

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
