### PR TITLE
fixes issue where multiple y axes overlap each other on the left rath…

### DIFF
--- a/px-vis-behavior-chart.html
+++ b/px-vis-behavior-chart.html
@@ -2334,9 +2334,10 @@ PxVisBehaviorChart.multiAxis = [{
       this.set('numRightAxes', rDims.length);
 
       this.set('axes', lDims.concat(rDims));
+		// need to set this before setting dimensions because the dimensions observer calls this for multi-axis
+		this.set('_axisX', this._setAxisScale(lDims.sort(), rDims.sort(), this.leftAxisSize, this.rightAxisSize));
       this.set('dimensions', this.axes);
       this.set('seriesToAxes', seriesToAxes);
-      this.set('_axisX', this._setAxisScale(lDims.sort(), rDims.sort(), this.leftAxisSize, this.rightAxisSize));
 
       if(typeof this._axisX === 'function') {
         this.set('_axisDomainChanged', this._axisDomainChanged + 1);


### PR DESCRIPTION
when APM Analysis upgraded to v5, multi-Y-axis functionality was broken. Specifically, our config to put alternate axes on left/right sides resulted in overlapping axes both on the left side. 