### PR TITLE
remove arrows when no lines appear

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-vis",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "main": [
     "px-vis.html"
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-vis",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "main": [
     "px-vis.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-vis",
   "author": "General Electric",
   "description": "A set of Px visualization components",
-  "version": "5.1.2",
+  "version": "5.1.8",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-vis-scatter-canvas.html
+++ b/px-vis-scatter-canvas.html
@@ -279,8 +279,12 @@ limitations under the License.
         //get the position of the symbol
         translate = this._getTransform(this.chartData[i]);
 
-        // draw arrow
-        if(this.showArrows && i !== start) {
+        // draw arrow :
+        // only draw if segment length is over x pixels AND the previous data point is valid
+        // this draw arrows only in the locations where lines are drawn
+        if(this.showArrows && i !== start
+          && this._isValidData(this.chartData[i-1][this.completeSeriesConfig[this.seriesId]['y']])
+          && this._isValidData(this.chartData[i-1][this.completeSeriesConfig[this.seriesId]['x']])) {
           tx = (translate[0] - previousTranslate[0])/2;
           ty = (translate[1] - previousTranslate[1])/2;
           // thank you Mr Pythagoras of Samos


### PR DESCRIPTION
# Pull Request

This PR is to remove the arrows when no line is present on the chart.
Use Case: when we enable show arrows for polar and filter the data on the chart, the lines disappear but the arrows remain on the chart. Not sure if this was intended to be that way but when this happens, the arrows looks to be phantom state without the lines.

The change is to fix the same by checking the validity of the previous data point. Additional comments in the fix location.