### PR TITLE
Removing empty check.

### DIFF
--- a/px-vis-event.html
+++ b/px-vis-event.html
@@ -265,7 +265,6 @@ Custom property | Description
     */
     _drawElementDebounced: function() {
       if(!this.svg ||
-          this._isObjEmpty(this.eventData) ||
           !this.domainChanged) {
         return;
       }


### PR DESCRIPTION
Use case:
clear pinnedMakers (eventData) on chart. 
Issue. Empty check is blocking further execution which are intended to clear markers on chart if eventData is empty.

# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
