### PR TITLE
fixes reset with zoom behavior, update bower & package version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "px-vis",
-  "version": "5.1.8",
+  "version": "5.1.10",
   "main": [
     "px-vis.html"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "px-vis",
   "author": "General Electric",
   "description": "A set of Px visualization components",
-  "version": "5.1.8",
+  "version": "5.1.10",
   "private": false,
   "extName": null,
   "repository": {

--- a/px-vis-behavior-chart.html
+++ b/px-vis-behavior-chart.html
@@ -1813,13 +1813,14 @@ PxVisBehaviorChart.zooming = [{
 
     this._saveOrdinalOriginalExtents();
 
-    var selectedDomain = this.selectedDomain;
+		var selectedDomain = this.selectedDomain === 'reset' ? {} : this.selectedDomain;
 
     if(!this.selectedDomain.y || this.selectedDomain.y.length === 0) {
-      selectedDomain.y = this._processYValues(function(axis, index) {
+      var newY = this._processYValues(function(axis, index) {
         return axis.domain();
       });
-    }
+			selectedDomain.y = newY;
+		}
 
     this.push('zoomStack', selectedDomain);
   },


### PR DESCRIPTION
This PR fixes the issue  where users unable to zoom again after resetting it on xy scatter or line chart.

Also upgrades the versions in bower & package json. Increasing to 5.1.10 as 5.1.9 tag already exists.