### PR TITLE
Support for ordinal axis type

### DIFF
--- a/px-vis-axis.html
+++ b/px-vis-axis.html
@@ -389,10 +389,10 @@ Custom property | Description
 
       //support for tick format
       // https://github.com/mbostock/d3/wiki/Formatting#d3_format
-      if(this.tickFormat && !this._isOrdinalType(this.axisType)) {
+      if(this.tickFormat) {
         if(typeof this.tickFormat === 'function') {
           this._axis.tickFormat(this.tickFormat);
-        } else if(this.axisType === 'time') {
+        } else if(this.axisType === 'time' || this.axisType === 'ordinal') {
           this._axis.tickFormat(Px.d3.utcFormat(this.tickFormat));
         } else if(this.axisType === 'timeLocal') {
           this._axis.tickFormat(Px.d3.timeFormat(this.tickFormat));
@@ -403,7 +403,7 @@ Custom property | Description
 
       //support for tick values
       // https://github.com/d3/d3-axis/blob/master/README.md#axis_tickValues
-      if(this.tickValues && this.tickValues.length > 0 && !this._isOrdinalType(this.axisType)) {
+      if(this.tickValues && this.tickValues.length > 0) {
         //dont run if our domain is NaN. Otherwise raises errors
         if(!isNaN(this.axis.domain()[0]) && !isNaN(this.axis.domain()[1])) {
           this._axis.tickValues(this.tickValues);

--- a/px-vis-event.html
+++ b/px-vis-event.html
@@ -292,17 +292,21 @@ Custom property | Description
           .each(function(d,i) {
             _this._enterLine(d, i, this);
             _this._enterIcon(d, i, this);
+            _this._enterText(d, i, this);
           })
         .merge(this._eventBuilder)
           .each(function(d,i) {
             // since the config controls the type of icon (image vs svg) we append, we cannot just rely on d3 updating. Have to remove and reappend the correct icon type
             if(_this._eventConfigChanged) {
               Px.d3.select(this).select('.event-icon').remove();
+              Px.d3.select(this).select('.event-text').remove();
               _this._enterIcon(d, i, this);
+              _this._enterText(d, i, this);
             }
 
             _this._mergeLine(d, i, this);
             _this._mergeIcon(d, i, this);
+            _this._mergeText(d, i, this);
           });
 
       this._eventConfigChanged = false;
@@ -357,6 +361,26 @@ Custom property | Description
         .on('mouseenter', this._requestTooltip.bind(this,d,i,iconSvg.node()))
         .on('mouseleave', this._clearTooltipRequest.bind(this,d,i));
     },
+  
+    /**
+    * checks if the text property exists and adds 
+    * text to the element with the class event-text
+    *
+    * @method _enterText
+    */
+    _enterText: function(d, i, elem) {
+      const text = this._getConfigValue('text', d.label, false);
+      let iconSvg;
+
+      if(text) {
+        iconSvg = Px.d3.select(elem).append('text')
+        .text(text)
+        .attr('class', 'event-text')
+        .attr('font-size', '12px')
+        .style('font-family',this._checkThemeVariable('--px-vis-font-family', 'Comic Sans MS'))
+        .attr('font-style', this._checkThemeVariable('--px-vis-font-family', 'Comic Sans MS'));
+      }
+    },
 
     _mergeLine: function(d, i, elem) {
       const key = this._getConfigValue('dataKey', d.label, false);
@@ -395,6 +419,28 @@ Custom property | Description
 
       Px.d3.select(elem).select('.event-icon')
         .attr("transform", `${translate} ${scale}`);
+    },
+    /**
+    * checks if the textOffset property exists and adds 
+    * it to the element with the class event-text
+    *
+    * @method _mergeText
+    */
+    _mergeText: function(d, i, elem) {
+      const key = this._getConfigValue('dataKey', d.label, false);
+
+      if(!d[key]) {
+        return;
+      }
+
+      const offset = this._getConfigValue('textOffset', d.label, false) || [0, 0];
+
+      const x = this.x(d[key]) + offset[0];
+      const y = offset[1] - 5;
+      const translate = `translate(${x},${y})`;
+
+      Px.d3.select(elem).select('.event-text')
+        .attr("transform", `${translate}`);
     },
 
     /**

--- a/px-vis-markers.html
+++ b/px-vis-markers.html
@@ -328,7 +328,7 @@ limitations under the License.
           bRowSet = {},
           tRow,
           bRow,
-		  row,
+          row,
           tScale,
           bScale,
           type;
@@ -490,7 +490,16 @@ limitations under the License.
       }.bind(this)).right;
       const maxDomain = this.x.domain()[1];
       const minDomain = this.x.domain()[0];
-      const mouseTime = this.x.invert(adjustedMousePos[0]);
+      let mouseTime;
+      // inversion with ordinal scale
+      if(this.x._scaleType === 'ordinal') {
+        const domain = this.x.domain();
+        const range = this.x.range();
+        const scale = d3.scaleQuantize().domain(range).range(domain);
+        mouseTime = new Date(scale(adjustedMousePos[0]));
+      } else {
+        mouseTime = this.x.invert(adjustedMousePos[0]);
+      }
 
       const right = bisect(data, mouseTime);
       const left = Math.max(0, right ? right-1 : 0);

--- a/px-vis-register-item.html
+++ b/px-vis-register-item.html
@@ -153,7 +153,10 @@ Custom property | Description
       displayXValuesOnly: {
         type: Boolean,
         value: false
-      }
+      },
+			registerFormatCallback: {
+				type: Function
+			}
     },
 
     observers: [
@@ -201,6 +204,17 @@ Custom property | Description
               break;
 
             case 'ordinal':
+              var xTimestamp = this.data.value[xKey];
+        
+              xVal = this.data.value[xKey];
+              // checks if registerFormatCallback is available, if so executes it expecting a return value for xVal
+              // allowing the user to set their own functionality.
+              if(this.completeSeriesConfig && this.registerFormatCallback) {
+                xVal = this.registerFormatCallback(this.completeSeriesConfig, xTimestamp);
+							} 
+              xUnit = this.completeSeriesConfig[this.seriesKey]['xAxisUnit'] ? ` ${this.completeSeriesConfig[this.seriesKey]['xAxisUnit']}` : '';
+              slash = this.displayXValuesOnly ? '' : ' / ';
+              break;
             case 'scaleBand':
               xVal = this.data.value[xKey];
               xUnit = this.completeSeriesConfig[this.seriesKey]['xAxisUnit'] ? ' ' + this.completeSeriesConfig[this.seriesKey]['xAxisUnit'] : '';

--- a/px-vis-register.html
+++ b/px-vis-register.html
@@ -199,6 +199,7 @@ Custom property | Description
                       disable-click="[[disableClick]]"
                       muted-series="{{mutedSeries}}"
                       number-format="[[numberFormat]]"
+                      register-format-callback="[[registerFormatCallback]]"
                       number-format-culture="[[numberFormatCulture]]"
                       number-format-is-currency="[[numberFormatIsCurrency]]"
                       number-format-currency="[[numberFormatCurrency]]"
@@ -475,7 +476,10 @@ Custom property | Description
         type: Boolean,
         computed: '_computeHasHeaderData(_showDateTime, _sortTypes.length, displayOrdinalValue)'
       },
-      _timeSeriesKey: String
+      _timeSeriesKey: String,
+      registerFormatCallback: {
+        type: Function
+      }
     },
 
     observers: [

--- a/px-vis-tooltip.html
+++ b/px-vis-tooltip.html
@@ -95,6 +95,7 @@ Custom property | Description
             complete-series-config="[[_mutedCompleteSeriesConfig]]"
             muted-series="[[mutedSeries]]"
             number-format="[[numberFormat]]"
+            register-format-callback="[[registerFormatCallback]]"
             number-format-culture="[[numberFormatCulture]]"
             number-format-is-currency$="[[numberFormatIsCurrency]]"
             number-format-currency="[[numberFormatCurrency]]"
@@ -199,6 +200,9 @@ Custom property | Description
       _mutedTooltipData: {
         type: Object,
         computed: '_computeMutedData(tooltipData.*, mutedSeries, hardMute)'
+      },
+      registerFormatCallback: {
+        type: Function
       }
     },
     observers: ['_computeInternalHidden(hide, _mutedTooltipData)'],

--- a/test/px-vis-register-fixture.html
+++ b/test/px-vis-register-fixture.html
@@ -107,6 +107,10 @@ limitations under the License.
     <div>
       <px-vis-register id="ordinal" x-axis-type="ordinal"></px-vis-register>
     </div>
+    <h2>Ordinal register with registerFormatCallback</h2>
+    <div>
+      <px-vis-register id="ordinalCallback" x-axis-type="ordinal"></px-vis-register>
+    </div>
     <h2>Ordinal units register</h2>
     <div>
       <px-vis-register id="ordinalUnits" x-axis-type="ordinal"></px-vis-register>

--- a/test/px-vis-register-tests.js
+++ b/test/px-vis-register-tests.js
@@ -37,7 +37,9 @@
 
   window.MouseEvent = MouseEvent;
 })(window);
-
+function registerFormatCallback(seriesConfig, time){
+  return `${time}${time}`;
+}
 document.addEventListener("WebComponentsReady", function() {
   runTests();
 });
@@ -353,6 +355,32 @@ function runTests() {
       assert.equal(series._displayedData, 'StringyString xUnit / 1,015.20 yUnit');
     });
   });
+  
+// ############################################################################
+// ############################################################################
+
+suite('px-vis-register x axis is ordinal and has a registerFormatCallback', function() {
+  var register;
+
+  suiteSetup(function(done) {
+    register = document.getElementById('ordinalCallback');
+    var data = generateOrdinalDataValues( generateEmptyData(2) );
+    setData(register, data);
+    register.set('registerFormatCallback', registerFormatCallback);
+    window.setTimeout(function() {
+      done();
+    }, 150);
+  });
+
+  test('ordinal fixtures are created', function() {
+    assert.isTrue(register !== null);
+  });
+
+  test('ordinal formated', function() {
+    var series = Polymer.dom(register.root).querySelector('px-vis-register-item');
+    assert.equal(series._displayedData, 'StringyStringStringyString xUnit / 1,015.20 yUnit');
+  });
+});
 
 // ############################################################################
 // ############################################################################


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
1. This PR provides the ability to add ordinal chart type and this is a feature requirement for Event analysis which uses ordinal chart type, changes have been made to the px-vis-axis, px-vis-event, px-vis-markers, px-vis-register, px-vis-register-item and px-vis-tooltip to facilitate the ordinal type.
2. Also for event markers, added code to allow text per event in addition to the icons.
3. Please note that appropriate comments have been added inline.

* ## A reference to a related issue (if applicable):

* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
