### PR TITLE
checks if the marker is top or bottom

### DIFF
--- a/px-vis-markers.html
+++ b/px-vis-markers.html
@@ -452,9 +452,9 @@ limitations under the License.
         this._closeTooltip();
         return;
       }
-
+      const location = mousePos[1] < this.height / 2 ? 'top' : 'bottom';
       //find all marker types for this row
-      const labels = this._findLabelsForRow(rowInfo.index);
+      const labels = this._findLabelsForRow(rowInfo.index, location);
 
       // if no markers we want a tooltip on in that row
       if(labels.length === 0) {
@@ -718,12 +718,12 @@ limitations under the License.
         return {'index': domain[domainIndex], 'rowY': rowY};
     },
 
-    _findLabelsForRow: function(rowIndex) {
+    _findLabelsForRow: function(rowIndex, location) {
       const index = Number(rowIndex);
       const result = [];
 
       Object.entries(this._markerConfig).forEach(([key,conf]) => {
-        if(index === conf.row && conf.showTooltip) {
+        if(location === conf.location && index === conf.row && conf.showTooltip) {
           result.push(key);
         }
       });


### PR DESCRIPTION
# Pull Request

Hi,

Thanks for helping us improve the Predix UI platform by submitting a Pull Request.

To help us merge your Pull Request as fast as possible, please fill out the following sections:

* ## A description of the changes proposed in the pull request:
validate the location to see if its top or bottom as it will try to get the rows IE. 2 and will find both instead of only one
* ## A reference to a related issue (if applicable):
send a marker config that has markers with location top row: 2 and location bottom row:2 as well but different values on x axis
then hover over on bottom and you will see that some places that has nothing will show the top markers and viceversa
as the code will try to look for the data to populate the tooltip and will find the row where the mouse is pointing to. However we have 2 rows 2 the one at top and one at bottom.
that will cause the code to treat them as if they were on the same y position.
We can see that at the method _searchTooltip of px-vis-markers
* ## @mentions of the person or team responsible for reviewing proposed changes:

* ## working tests:
#### The tests need to be functional and/or unit tests, written for the wct framework, and placed in the test folder, following our testing guidelines.
